### PR TITLE
Add option to forbidding loading items to SelectBox

### DIFF
--- a/src/Kdyby/DoctrineForms/Controls/TextControl.php
+++ b/src/Kdyby/DoctrineForms/Controls/TextControl.php
@@ -154,7 +154,9 @@ class TextControl extends Nette\Object implements IComponentMapper
 		}
 
 		if ($meta->hasField($name = $component->getOption(self::FIELD_NAME, $component->getName()))) {
-			$this->accessor->setValue($entity, $name, $component->getValue());
+			if(!$component->getOption(self::FIELD_NOT_SAVE, false)){
+				$this->accessor->setValue($entity, $name, $component->getValue());
+			}
 			return TRUE;
 		}
 

--- a/src/Kdyby/DoctrineForms/Controls/TextControl.php
+++ b/src/Kdyby/DoctrineForms/Controls/TextControl.php
@@ -75,7 +75,7 @@ class TextControl extends Nette\Object implements IComponentMapper
 		}
 
 		/** @var SelectBox|RadioList $component */
-		if (($component instanceof SelectBox || $component instanceof RadioList) && !count($component->getItems())) {
+		if (($component instanceof SelectBox || $component instanceof RadioList) && !count($component->getItems()) && !$component->getOption(self::FIELD_NOT_LOAD, false)) {
 			if (!$nameKey = $component->getOption(self::ITEMS_TITLE, FALSE)) {
 				$path = $component->lookupPath('Nette\Application\UI\Form');
 				throw new Kdyby\DoctrineForms\InvalidStateException(

--- a/src/Kdyby/DoctrineForms/IComponentMapper.php
+++ b/src/Kdyby/DoctrineForms/IComponentMapper.php
@@ -25,6 +25,7 @@ interface IComponentMapper
 
 	const FIELD_NAME = 'field.name';
 	const FIELD_NOT_LOAD = 'field.notLoad';
+	const FIELD_NOT_SAVE = 'field.notSave';
 	const ITEMS_TITLE = 'items.title';
 	const ITEMS_FILTER = 'items.filter';
 	const ITEMS_ORDER = 'items.order';

--- a/src/Kdyby/DoctrineForms/IComponentMapper.php
+++ b/src/Kdyby/DoctrineForms/IComponentMapper.php
@@ -24,6 +24,7 @@ interface IComponentMapper
 {
 
 	const FIELD_NAME = 'field.name';
+	const FIELD_NOT_LOAD = 'field.notLoad';
 	const ITEMS_TITLE = 'items.title';
 	const ITEMS_FILTER = 'items.filter';
 	const ITEMS_ORDER = 'items.order';


### PR DESCRIPTION
When I manually add items to selectbox ant there is not any item, so this change allow to have selectbox with zero items and not allow to load items by entity mapper.
